### PR TITLE
 Hide old logo until new one

### DIFF
--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -8,7 +8,7 @@
     <meta name="og_type" content="website" />
     <meta name="og_title" content="PyConFr 2018 - Lille" />
     <meta name="og_description" content="Du 4 au 7 octobre 2018 se tiendra la conférence rassemblant les développeurs et développeuses Python francophones" />
-    <meta name="og_image" content="images/logo.png" />
+    <!-- <meta name="og_image" content="images/logo.png" /> -->
   </head>
 
   <body>


### PR DESCRIPTION
Pour le partage du site, autant laisser les plateformes afficher une miniature du site ou rien du tout plutôt que le logo de 2017 lié à Toulouse.

La balise meta pourra être réactivé quand on aura le logo de cette année :)