### PR TITLE
Remplacer la majuscule du L à L'AFPy

### DIFF
--- a/content/pages/fr/about.rst
+++ b/content/pages/fr/about.rst
@@ -20,7 +20,7 @@ Lille
 du 4 au 7 octobre 2018
 ----------------------
 
-Organisée par `L'AFPy <http://www.afpy.org/>`_, cette conférence est gratuite,
+Organisée par `l'AFPy <http://www.afpy.org/>`_, cette conférence est gratuite,
 entièrement organisée par des bénévoles et regroupe les personnes intéressées
 par le langage de programmation `Python <http://www.python.org/>`_.
 


### PR DESCRIPTION
L'AFPy -> l'AFPy

ça me semble normal et c'est aussi comme ça sur la page d'accueil de https://www.afpy.org/