### PR TITLE
Espace interligne identique pour les sponsors quelque soit le nombre …

### DIFF
--- a/theme/static/css/style.sass
+++ b/theme/static/css/style.sass
@@ -819,6 +819,9 @@ footer
   .text-center
     text-align: center
 
+  .docutils
+    line-height: 1.8em
+
 /* Page Articles */
 
 .hentry


### PR DESCRIPTION
…de paragraphes pour leur présentation

Docutils ne génère pas le même DOM selon que la présentation fasse un ou plusieurs paragraphes:
```html
<div class="docutils container">
   un seul paragraphe
</div>

<div class="docutils container">
<p>paragraphe 1</p>
<p>paragraphe 2</p>
</div>
```

Le problème est présent pour Anybox et Yaal.

L'absence de balise ```p``` fait que l'interligne par défaut n'est pas pris en compte. Cette PR reprend l'interlignage prévu à l'ajoutant à la classe ```docutils```. La balise ```p``` a aussi des éléments de style sur les liens mais il n'y en a pas dans les présentations donc ce n'est pas un problème.

À mon avis, cette PR est un contournement d'un comportement incorrect de docutils. Je prévois de les contacter à ce sujet mais au moins on a une correction directe pour le site de la pyconfr.