### PR TITLE
Suppression des liens permettant de proposer des présentations

### DIFF
--- a/content/pages/en/about.rst
+++ b/content/pages/en/about.rst
@@ -31,7 +31,6 @@ coordinated by volunteers and brings together people interested by the `Python
   <section class="wrap-button">
     <p>
       <a class="btn-home" href="/en/sponsor-pyconfr">Sponsor PyConFr</a>
-      <a class="btn-home" href="https://cfp-2018.pycon.fr/cfp/">Propose a talk</a>
     </p>
   </section>
 

--- a/content/pages/fr/about.rst
+++ b/content/pages/fr/about.rst
@@ -31,7 +31,6 @@ par le langage de programmation `Python <http://www.python.org/>`_.
   <section class="wrap-button">
     <p>
       <a class="btn-home" href="/fr/sponsor-pyconfr">Financer PyConFr</a>
-      <a class="btn-home" href="https://cfp-2018.pycon.fr/cfp/">Proposer une présentation</a>
     </p>
   </section>
 


### PR DESCRIPTION
Étant donné que les propositions de présentation sont closes depuis un ou deux mois et qu'il y a un programme préliminaire, je pense que le lien devrait être supprimé (ou caché si vous repartez du site d'une année sur l'autre?)